### PR TITLE
Cap expiration duration, set ttl in time.Duration, and allow email or https link subjects.

### DIFF
--- a/.github/workflows/go-v2.yml
+++ b/.github/workflows/go-v2.yml
@@ -1,0 +1,29 @@
+name: Go
+
+on:
+  push:
+    branches: ["v2"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          check-latest: true
+      - run: go test -v
+  release:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+      - uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          changelog-file: CHANGELOG.md
+          changelog-generator-opt: "emojis=true"
+          custom-arguments: "--no-ci"
+          prerelease: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: ["v2"]
+    branches: ["**"]
   pull_request:
-    branches: ["v2"]
+    branches: ["**"]
 
 jobs:
   test:
@@ -16,16 +16,3 @@ jobs:
           go-version: "stable"
           check-latest: true
       - run: go test -v
-  release:
-    runs-on: ubuntu-latest
-    needs: test
-    permissions: write-all
-    steps:
-      - uses: actions/checkout@v4
-      - uses: go-semantic-release/action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          changelog-file: CHANGELOG.md
-          changelog-generator-opt: "emojis=true"
-          custom-arguments: "--no-ci"
-          prerelease: true

--- a/misc.go
+++ b/misc.go
@@ -8,6 +8,8 @@ import (
 
 func formatVAPIDJWTSubject(input string) (string, error) {
 
+	input = strings.TrimPrefix(input, "mailto:")
+
 	if _, err := mail.ParseAddress(input); err == nil {
 
 		b := strings.Builder{}

--- a/misc.go
+++ b/misc.go
@@ -1,0 +1,26 @@
+package webpush
+
+import (
+	"net/mail"
+	"net/url"
+	"strings"
+)
+
+func formatSubscriber(input string) (string, error) {
+
+	if _, err := mail.ParseAddress(input); err == nil {
+
+		b := strings.Builder{}
+
+		b.WriteString("mailto:")
+		b.WriteString(input)
+
+		return b.String(), nil
+	}
+
+	if result, err := url.Parse(input); err == nil && result.Scheme == "https" {
+		return input, nil
+	}
+
+	return "", ErrInvalidSubscriber
+}

--- a/misc.go
+++ b/misc.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func formatSubscriber(input string) (string, error) {
+func formatVAPIDJWTSubject(input string) (string, error) {
 
 	if _, err := mail.ParseAddress(input); err == nil {
 

--- a/misc_test.go
+++ b/misc_test.go
@@ -45,6 +45,12 @@ func Test_formatSubscriber(t *testing.T) {
 			want:    "mailto:john@doe.com",
 			wantErr: false,
 		},
+		{
+			name:    "email - 2",
+			arg:     "mailto:john@doe.com",
+			want:    "mailto:john@doe.com",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/misc_test.go
+++ b/misc_test.go
@@ -1,0 +1,61 @@
+package webpush
+
+import "testing"
+
+func Test_formatSubscriber(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "blank",
+			arg:     "",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "unencrypted http check",
+			arg:     "http://example.com",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "https check",
+			arg:     "https://example.com",
+			want:    "https://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "sftp check",
+			arg:     "sftp://example.com",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "random text",
+			arg:     "randomtext",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "email",
+			arg:     "john@doe.com",
+			want:    "mailto:john@doe.com",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := formatSubscriber(tt.arg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("formatSubscriber() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("formatSubscriber() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/misc_test.go
+++ b/misc_test.go
@@ -48,7 +48,7 @@ func Test_formatSubscriber(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := formatSubscriber(tt.arg)
+			got, err := formatVAPIDJWTSubject(tt.arg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("formatSubscriber() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/vapid.go
+++ b/vapid.go
@@ -65,7 +65,7 @@ func generateVAPIDHeaderKeys(privateKey []byte) *ecdsa.PrivateKey {
 // getVAPIDAuthorizationHeader
 func getVAPIDAuthorizationHeader(
 	endpoint,
-	subscriber,
+	subject,
 	vapidPublicKey,
 	vapidPrivateKey string,
 	expiration time.Time,
@@ -79,7 +79,7 @@ func getVAPIDAuthorizationHeader(
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
 		"aud": fmt.Sprintf("%s://%s", subURL.Scheme, subURL.Host),
 		"exp": expiration.Unix(),
-		"sub": subscriber,
+		"sub": subject,
 	})
 
 	// Decode the VAPID private key

--- a/vapid.go
+++ b/vapid.go
@@ -79,7 +79,7 @@ func getVAPIDAuthorizationHeader(
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
 		"aud": fmt.Sprintf("%s://%s", subURL.Scheme, subURL.Host),
 		"exp": expiration.Unix(),
-		"sub": fmt.Sprintf("mailto:%s", subscriber),
+		"sub": subscriber,
 	})
 
 	// Decode the VAPID private key

--- a/vapid.go
+++ b/vapid.go
@@ -76,6 +76,11 @@ func getVAPIDAuthorizationHeader(
 		return "", err
 	}
 
+	subject, err = formatVAPIDJWTSubject(subject)
+	if err != nil {
+		return "", err
+	}
+
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
 		"aud": fmt.Sprintf("%s://%s", subURL.Scheme, subURL.Host),
 		"exp": expiration.Unix(),

--- a/webpush.go
+++ b/webpush.go
@@ -208,8 +208,15 @@ func SetTTLDuration(ttl time.Duration) Option {
 }
 
 // Set the expiration for VAPID JWT token
+//
+// Duration is capped to 24 hours. See https://www.rfc-editor.org/rfc/rfc8292#section-2
 func SetExpirationDuration(d time.Duration) Option {
 	return option(func(o *Client) error {
+
+		if d >= 24*time.Hour {
+			d = 24 * time.Hour
+		}
+
 		o.expirationDuration = d
 		return nil
 	})
@@ -245,7 +252,7 @@ func New(sub, private, public string, opts ...Option) (*Client, error) {
 
 	var err error
 
-	sub, err = formatSubscriber(sub)
+	sub, err = formatVAPIDJWTSubject(sub)
 	if err != nil {
 		return nil, err
 	}

--- a/webpush.go
+++ b/webpush.go
@@ -26,7 +26,7 @@ const (
 	MaxRecordSize   uint32 = 4096
 	DefaultDuration        = time.Second * 30
 	DefaultTimeout         = time.Second * 30
-	DefaultTTL             = 30
+	DefaultTTL             = time.Second * 30
 )
 
 var (
@@ -58,16 +58,16 @@ type HTTPClient interface {
 
 // Client configuration that's needed to send a notification.
 type Client struct {
-	client         HTTPClient
-	recordSize     uint32
-	subscriber     string
-	topic          string
-	ttl            int
-	urgency        Urgency
-	duration       time.Duration
-	privateKey     string
-	publicKey      string
-	excludeZeroTTL []string
+	client             HTTPClient
+	recordSize         uint32
+	subscriber         string
+	topic              string
+	ttl                time.Duration
+	urgency            Urgency
+	expirationDuration time.Duration
+	privateKey         string
+	publicKey          string
+	excludeZeroTTL     []string
 }
 
 // Check if the client will skip the endpoint.
@@ -75,12 +75,12 @@ type Client struct {
 // Example: if you use SetTTL(0, "windows.com"), it will return true for "https://wns2-by3p.notify.windows.com/....".
 func (c Client) SkipForEndpoint(endpoint string) bool {
 
-	ep, err := url.Parse(endpoint)
-	if err != nil {
+	if c.ttl > 0 || len(c.excludeZeroTTL) == 0 {
 		return false
 	}
 
-	if len(c.excludeZeroTTL) == 0 {
+	ep, err := url.Parse(endpoint)
+	if err != nil {
 		return false
 	}
 
@@ -179,17 +179,29 @@ func SetUrgency(urgency Urgency) Option {
 	})
 }
 
-// Set the TTL on the endpoint POST request.
+// Set the TTL in seconds on the endpoint POST request.
 //
 // Certain browsers may have issues when TTL is set to 0. TTL must be >= 0 to be set.
 //
-// You can set the domains to exclude the zero ttl header with the exclude variable.
+// You can set the domains to exclude the zero ttl header with the exclude variable. This is not recommended.
 func SetTTL(ttl int, exclude ...string) Option {
 	return option(func(o *Client) error {
 		if ttl >= 0 {
-			o.ttl = ttl
+			o.ttl = time.Duration(ttl) * time.Second
 		}
-		o.excludeZeroTTL = exclude
+		if ttl == 0 {
+			o.excludeZeroTTL = exclude
+		}
+		return nil
+	})
+}
+
+// Set the TTL Duration on the endpoint POST request.
+//
+// Certain browsers may have issues when the TTL is set to 0.
+func SetTTLDuration(ttl time.Duration) Option {
+	return option(func(c *Client) error {
+		c.ttl = ttl
 		return nil
 	})
 }
@@ -197,7 +209,7 @@ func SetTTL(ttl int, exclude ...string) Option {
 // Set the expiration for VAPID JWT token
 func SetExpirationDuration(d time.Duration) Option {
 	return option(func(o *Client) error {
-		o.duration = d
+		o.expirationDuration = d
 		return nil
 	})
 }
@@ -231,13 +243,13 @@ func SetPublicKey(key string) Option {
 func New(sub, private, public string, opts ...Option) (*Client, error) {
 
 	o := &Client{
-		client:     &http.Client{Timeout: DefaultTimeout},
-		subscriber: sub,
-		privateKey: private,
-		publicKey:  public,
-		recordSize: MaxRecordSize,
-		duration:   DefaultDuration,
-		ttl:        DefaultTTL,
+		client:             &http.Client{Timeout: DefaultTimeout},
+		subscriber:         sub,
+		privateKey:         private,
+		publicKey:          public,
+		recordSize:         MaxRecordSize,
+		expirationDuration: DefaultDuration,
+		ttl:                DefaultTTL,
 	}
 
 	if err := o.Set(opts...); err != nil {
@@ -290,16 +302,16 @@ func (o *Client) SendWithContext(ctx context.Context, s Subscription, message []
 
 	// Copy the options
 	options := &Client{
-		client:         o.client,
-		recordSize:     o.recordSize,
-		subscriber:     o.subscriber,
-		topic:          o.topic,
-		ttl:            o.ttl,
-		urgency:        o.urgency,
-		duration:       o.duration,
-		privateKey:     o.privateKey,
-		publicKey:      o.publicKey,
-		excludeZeroTTL: o.excludeZeroTTL,
+		client:             o.client,
+		recordSize:         o.recordSize,
+		subscriber:         o.subscriber,
+		topic:              o.topic,
+		ttl:                o.ttl,
+		urgency:            o.urgency,
+		expirationDuration: o.expirationDuration,
+		privateKey:         o.privateKey,
+		publicKey:          o.publicKey,
+		excludeZeroTTL:     o.excludeZeroTTL,
 	}
 
 	if err := options.Set(overrides...); err != nil {
@@ -424,8 +436,9 @@ func (o *Client) SendWithContext(ctx context.Context, s Subscription, message []
 	req.Header.Set("Content-Length", strconv.Itoa(int(recordSize)))
 	req.Header.Set("Content-Type", "application/octet-stream")
 
+	// Not recommended
 	if !options.SkipForEndpoint(s.Endpoint) {
-		req.Header.Set("TTL", strconv.Itoa(options.ttl))
+		req.Header.Set("TTL", fmt.Sprintf("%.0f", options.ttl.Seconds()))
 	}
 
 	// Сheck the optional headers
@@ -437,13 +450,13 @@ func (o *Client) SendWithContext(ctx context.Context, s Subscription, message []
 		req.Header.Set("Urgency", options.urgency.String())
 	}
 
-	dur := options.duration
+	dur := options.expirationDuration
 
 	if dur == 0 {
 
 	}
 
-	expiration := time.Now().Add(options.duration)
+	expiration := time.Now().Add(options.expirationDuration)
 
 	// Get VAPID Authorization header
 	vapidAuthHeader, err := getVAPIDAuthorizationHeader(


### PR DESCRIPTION
`webpush.SetExpirationDuration` now has a 24 hour cap. See https://www.rfc-editor.org/rfc/rfc8292#section-2

You're now able to set the TTL in time.Duration.

Emails and https links are both allowed for sub field in `webpush.New`